### PR TITLE
Don't fall through between cases in light_mem_seek()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.tmp
 /.vs
 /out
+/build

--- a/src/light_io_mem.c
+++ b/src/light_io_mem.c
@@ -67,10 +67,13 @@ int light_mem_seek(void* context, long int offset, int origin)
 	{
 	case SEEK_SET:
 		new_offset = offset;
+		break;
 	case	SEEK_CUR:
 		new_offset += offset;
+		break;
 	case	SEEK_END:
 		new_offset = mem->size + offset;
+		break;
 	}
 	if (new_offset < 0 || new_offset > mem->size) {
 		return 1;


### PR DESCRIPTION
The switch statement in the function `light_mem_seek()` falls through all of the cases, resulting in an invalid offset, as described in issue #32.