### PR TITLE
Fix warnings

### DIFF
--- a/src/light_io.c
+++ b/src/light_io.c
@@ -48,7 +48,9 @@ light_file light_io_open(const char* filename, const char* mode)
 	if (!filename) {
 		return NULL;
 	}
+#if defined(LIGHT_USE_ZSTD) || defined(LIGHT_USE_ZLIB)
 	const char* ext = get_filename_ext(filename);
+#endif
 
 #if defined(LIGHT_USE_ZSTD)
 	if (strcasecmp(ext, ".zst") == 0) {

--- a/src/light_pcapng.c
+++ b/src/light_pcapng.c
@@ -416,14 +416,6 @@ void light_free_block(light_block block)
 	}
 }
 
-static int __option_count(light_option option)
-{
-	if (option == NULL)
-		return 0;
-
-	return 1 + __option_count(option->next_option);
-}
-
 uint32_t* __options_to_mem(const light_option option, size_t* size)
 {
 	if (option == NULL) {

--- a/src/light_pcapng_ext.c
+++ b/src/light_pcapng_ext.c
@@ -385,7 +385,9 @@ int light_read_packet(light_pcapng pcapng, light_packet_interface* packet_interf
 		if (flags_opt != NULL && flags_opt->length == sizeof(uint32_t))
 		{
 			packet_header->flags = *(uint32_t*)(flags_opt->data);
-			if (pcapng->swap_endianness) bswap32(packet_header->flags);
+			if (pcapng->swap_endianness) {
+				packet_header->flags = bswap32(packet_header->flags);
+			}
 		}
 
 		packet_header->dropcount = 0;
@@ -393,7 +395,9 @@ int light_read_packet(light_pcapng pcapng, light_packet_interface* packet_interf
 		if (dropcount_opt != NULL && dropcount_opt->length != 0)
 		{
 			packet_header->dropcount = *(uint64_t*)(dropcount_opt->data);
-			if (pcapng->swap_endianness) bswap64(packet_header->dropcount);
+			if (pcapng->swap_endianness) {
+				packet_header->dropcount = bswap64(packet_header->dropcount);
+			}
 		}
 
 		packet_header->queue = 0;
@@ -401,7 +405,9 @@ int light_read_packet(light_pcapng pcapng, light_packet_interface* packet_interf
 		if (queue_opt != NULL && queue_opt->length != 0)
 		{
 			packet_header->queue = *(uint32_t*)(queue_opt->data);
-			if (pcapng->swap_endianness) bswap32(packet_header->queue);
+			if (pcapng->swap_endianness) {
+				packet_header->queue = bswap32(packet_header->queue);
+			}
 		}
 
 		*packet_data = epb->packet_data;

--- a/src/light_pcapng_ext.c
+++ b/src/light_pcapng_ext.c
@@ -439,8 +439,6 @@ int safe_strcmp(char const* str1, char const* str2) {
 	return strcmp(str1, str2);
 }
 
-static const uint8_t NSEC_PRECISION = 9;
-
 uint8_t get_timestamp_resolution_precision(uint64_t timestamp_resolution) {
 	uint64_t time_value = timestamp_resolution;
 	uint8_t precision = 0;


### PR DESCRIPTION
Hi. This fixes unused function/variable warnings emitted by GCC and Clang. It also addresses a bug in endianess conversion, where the result of the swap is not assigned back (also detected by GCC warnings).