### PR TITLE
light_io function improvements

### DIFF
--- a/include/light_io.h
+++ b/include/light_io.h
@@ -34,6 +34,7 @@ LIGHT_API size_t LIGHT_API_CALL light_io_read(light_file fd, void* buf, size_t c
 LIGHT_API size_t LIGHT_API_CALL light_io_write(light_file fd, const void* buf, size_t count);
 
 LIGHT_API int LIGHT_API_CALL light_io_seek(light_file fd, long int offset, int origin);
+LIGHT_API long LIGHT_API_CALL light_io_tell(light_file fd);
 LIGHT_API int LIGHT_API_CALL light_io_flush(light_file fd);
 LIGHT_API int LIGHT_API_CALL light_io_close(light_file fd);
 

--- a/include/light_io.h
+++ b/include/light_io.h
@@ -34,8 +34,8 @@ LIGHT_API light_file LIGHT_API_CALL light_io_open(const char* file_name, const c
 LIGHT_API size_t LIGHT_API_CALL light_io_read(light_file fd, void* buf, size_t count);
 LIGHT_API size_t LIGHT_API_CALL light_io_write(light_file fd, const void* buf, size_t count);
 
-LIGHT_API int64_t LIGHT_API_CALL light_io_seek(light_file fd, int64_t offset, int origin);
-LIGHT_API int64_t LIGHT_API_CALL light_io_offset(light_file fd);
+LIGHT_API int LIGHT_API_CALL light_io_seek(light_file fd, off_t offset, int origin);
+LIGHT_API off_t LIGHT_API_CALL light_io_offset(light_file fd);
 LIGHT_API int LIGHT_API_CALL light_io_flush(light_file fd);
 LIGHT_API int LIGHT_API_CALL light_io_close(light_file fd);
 

--- a/include/light_io.h
+++ b/include/light_io.h
@@ -25,6 +25,7 @@
 #include "light_export.h"
 
 #include <stdio.h>
+#include <stdint.h>
 
 typedef struct light_file_t* light_file;
 
@@ -33,8 +34,8 @@ LIGHT_API light_file LIGHT_API_CALL light_io_open(const char* file_name, const c
 LIGHT_API size_t LIGHT_API_CALL light_io_read(light_file fd, void* buf, size_t count);
 LIGHT_API size_t LIGHT_API_CALL light_io_write(light_file fd, const void* buf, size_t count);
 
-LIGHT_API int LIGHT_API_CALL light_io_seek(light_file fd, long int offset, int origin);
-LIGHT_API long LIGHT_API_CALL light_io_tell(light_file fd);
+LIGHT_API int64_t LIGHT_API_CALL light_io_seek(light_file fd, int64_t offset, int origin);
+LIGHT_API int64_t LIGHT_API_CALL light_io_offset(light_file fd);
 LIGHT_API int LIGHT_API_CALL light_io_flush(light_file fd);
 LIGHT_API int LIGHT_API_CALL light_io_close(light_file fd);
 

--- a/include/light_pcapng_ext.h
+++ b/include/light_pcapng_ext.h
@@ -93,6 +93,8 @@ LIGHT_API int LIGHT_API_CALL light_pcapng_close(light_pcapng pcapng);
 
 LIGHT_API int LIGHT_API_CALL light_pcapng_flush(light_pcapng pcapng);
 
+LIGHT_API long LIGHT_API_CALL light_pcapng_tell(light_pcapng pcapng);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/light_pcapng_ext.h
+++ b/include/light_pcapng_ext.h
@@ -31,7 +31,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
-#ifdef _WIN32  
+#ifdef _WIN32
 #include <time.h>
 #else
 #include <sys/time.h>
@@ -93,7 +93,7 @@ LIGHT_API int LIGHT_API_CALL light_pcapng_close(light_pcapng pcapng);
 
 LIGHT_API int LIGHT_API_CALL light_pcapng_flush(light_pcapng pcapng);
 
-LIGHT_API long LIGHT_API_CALL light_pcapng_tell(light_pcapng pcapng);
+LIGHT_API int64_t LIGHT_API_CALL light_pcapng_offset(light_pcapng pcapng);
 
 #ifdef __cplusplus
 }

--- a/include/light_pcapng_ext.h
+++ b/include/light_pcapng_ext.h
@@ -30,6 +30,7 @@ extern "C" {
 #include "light_io.h"
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdbool.h>
 #ifdef _WIN32
 #include <time.h>
@@ -93,7 +94,7 @@ LIGHT_API int LIGHT_API_CALL light_pcapng_close(light_pcapng pcapng);
 
 LIGHT_API int LIGHT_API_CALL light_pcapng_flush(light_pcapng pcapng);
 
-LIGHT_API int64_t LIGHT_API_CALL light_pcapng_offset(light_pcapng pcapng);
+LIGHT_API off_t LIGHT_API_CALL light_pcapng_offset(light_pcapng pcapng);
 
 #ifdef __cplusplus
 }

--- a/src/light_io.c
+++ b/src/light_io.c
@@ -91,6 +91,14 @@ int light_io_seek(light_file fd, long int offset, int origin)
 	return fd->fn_seek(fd->context, offset, origin);
 }
 
+long light_io_tell(light_file fd)
+{
+	if (fd->fn_tell == NULL) {
+		return -1;
+	}
+	return fd->fn_tell(fd->context);
+}
+
 int light_io_flush(light_file fd)
 {
 	if (fd->fn_flush == NULL) {

--- a/src/light_io.c
+++ b/src/light_io.c
@@ -83,7 +83,7 @@ size_t light_io_write(light_file fd, const void* buf, size_t count)
 	return fd->fn_write(fd->context, buf, count);
 }
 
-int64_t light_io_seek(light_file fd, int64_t offset, int origin)
+int light_io_seek(light_file fd, off_t offset, int origin)
 {
 	if (fd->fn_seek == NULL) {
 		return -1;
@@ -91,7 +91,7 @@ int64_t light_io_seek(light_file fd, int64_t offset, int origin)
 	return fd->fn_seek(fd->context, offset, origin);
 }
 
-int64_t light_io_offset(light_file fd)
+off_t light_io_offset(light_file fd)
 {
 	if (fd->fn_offset == NULL) {
 		return -1;

--- a/src/light_io.c
+++ b/src/light_io.c
@@ -83,7 +83,7 @@ size_t light_io_write(light_file fd, const void* buf, size_t count)
 	return fd->fn_write(fd->context, buf, count);
 }
 
-int light_io_seek(light_file fd, long int offset, int origin)
+int64_t light_io_seek(light_file fd, int64_t offset, int origin)
 {
 	if (fd->fn_seek == NULL) {
 		return -1;
@@ -91,12 +91,12 @@ int light_io_seek(light_file fd, long int offset, int origin)
 	return fd->fn_seek(fd->context, offset, origin);
 }
 
-long light_io_tell(light_file fd)
+int64_t light_io_offset(light_file fd)
 {
-	if (fd->fn_tell == NULL) {
+	if (fd->fn_offset == NULL) {
 		return -1;
 	}
-	return fd->fn_tell(fd->context);
+	return fd->fn_offset(fd->context);
 }
 
 int light_io_flush(light_file fd)

--- a/src/light_io_file.c
+++ b/src/light_io_file.c
@@ -71,6 +71,7 @@ light_file light_io_file_create(FILE* file)
 	fd->fn_read = &light_file_read;
 	fd->fn_write = &light_file_write;
 	fd->fn_flush = &light_file_flush;
+	fd->fn_seek = &light_file_seek;
 	fd->fn_close = &light_file_close;
 	return fd;
 }

--- a/src/light_io_file.c
+++ b/src/light_io_file.c
@@ -42,6 +42,12 @@ int light_file_seek(void* context, long int offset, int origin)
 	return fseek(file, offset, origin);
 }
 
+long light_file_tell(void* context)
+{
+	FILE* file = context;
+	return ftell(file);
+}
+
 int light_file_flush(void* context)
 {
 	FILE* file = context;
@@ -72,6 +78,7 @@ light_file light_io_file_create(FILE* file)
 	fd->fn_write = &light_file_write;
 	fd->fn_flush = &light_file_flush;
 	fd->fn_seek = &light_file_seek;
+	fd->fn_tell = &light_file_tell;
 	fd->fn_close = &light_file_close;
 	return fd;
 }

--- a/src/light_io_file.c
+++ b/src/light_io_file.c
@@ -22,7 +22,7 @@
 #include "light_io_file.h"
 #include "light_io_internal.h"
 #include <stdio.h>
-#include <stdlib.h> 
+#include <stdlib.h>
 
 size_t light_file_read(void* context, void* buf, size_t count)
 {
@@ -36,16 +36,16 @@ size_t light_file_write(void* context, const void* buf, size_t count)
 	return fwrite(buf, 1, count, file);
 }
 
-int light_file_seek(void* context, long int offset, int origin)
+int64_t light_file_seek(void* context, int64_t offset, int origin)
 {
 	FILE* file = context;
-	return fseek(file, offset, origin);
+	return fseeko64(file, offset, origin);
 }
 
-long light_file_tell(void* context)
+int64_t light_file_offset(void* context)
 {
 	FILE* file = context;
-	return ftell(file);
+	return ftello64(file);
 }
 
 int light_file_flush(void* context)
@@ -78,7 +78,7 @@ light_file light_io_file_create(FILE* file)
 	fd->fn_write = &light_file_write;
 	fd->fn_flush = &light_file_flush;
 	fd->fn_seek = &light_file_seek;
-	fd->fn_tell = &light_file_tell;
+	fd->fn_offset = &light_file_offset;
 	fd->fn_close = &light_file_close;
 	return fd;
 }

--- a/src/light_io_file.c
+++ b/src/light_io_file.c
@@ -36,16 +36,16 @@ size_t light_file_write(void* context, const void* buf, size_t count)
 	return fwrite(buf, 1, count, file);
 }
 
-int64_t light_file_seek(void* context, int64_t offset, int origin)
+int light_file_seek(void* context, off_t offset, int origin)
 {
 	FILE* file = context;
-	return fseeko64(file, offset, origin);
+	return fseeko(file, offset, origin);
 }
 
-int64_t light_file_offset(void* context)
+off_t light_file_offset(void* context)
 {
 	FILE* file = context;
-	return ftello64(file);
+	return ftello(file);
 }
 
 int light_file_flush(void* context)

--- a/src/light_io_internal.h
+++ b/src/light_io_internal.h
@@ -28,6 +28,7 @@
 typedef size_t(*light_fn_read)(void* context, void* buf, size_t count);
 typedef size_t(*light_fn_write)(void* context, const void* buf, size_t count);
 typedef int(*light_fn_seek)(void* context, long int offset, int origin);
+typedef long(*light_fn_tell)(void* context);
 typedef int(*light_fn_flush)(void* context);
 typedef int(*light_fn_close)(void* context);
 
@@ -38,6 +39,7 @@ struct light_file_t
 	light_fn_read fn_read;
 	light_fn_write fn_write;
 	light_fn_seek fn_seek;
+	light_fn_tell fn_tell;
 	light_fn_flush fn_flush;
 	light_fn_close fn_close;
 };

--- a/src/light_io_internal.h
+++ b/src/light_io_internal.h
@@ -23,12 +23,13 @@
 #define INCLUDE_LIGHT_IO_INTERNAL_H_
 
 #include "light_io.h"
-#include <stdio.h> 
+#include <stdio.h>
+#include <stdint.h>
 
 typedef size_t(*light_fn_read)(void* context, void* buf, size_t count);
 typedef size_t(*light_fn_write)(void* context, const void* buf, size_t count);
-typedef int(*light_fn_seek)(void* context, long int offset, int origin);
-typedef long(*light_fn_tell)(void* context);
+typedef int64_t(*light_fn_seek)(void* context, int64_t offset, int origin);
+typedef int64_t(*light_fn_offset)(void* context);
 typedef int(*light_fn_flush)(void* context);
 typedef int(*light_fn_close)(void* context);
 
@@ -39,7 +40,7 @@ struct light_file_t
 	light_fn_read fn_read;
 	light_fn_write fn_write;
 	light_fn_seek fn_seek;
-	light_fn_tell fn_tell;
+	light_fn_offset fn_offset;
 	light_fn_flush fn_flush;
 	light_fn_close fn_close;
 };

--- a/src/light_io_internal.h
+++ b/src/light_io_internal.h
@@ -28,8 +28,8 @@
 
 typedef size_t(*light_fn_read)(void* context, void* buf, size_t count);
 typedef size_t(*light_fn_write)(void* context, const void* buf, size_t count);
-typedef int64_t(*light_fn_seek)(void* context, int64_t offset, int origin);
-typedef int64_t(*light_fn_offset)(void* context);
+typedef int(*light_fn_seek)(void* context, off_t offset, int origin);
+typedef off_t(*light_fn_offset)(void* context);
 typedef int(*light_fn_flush)(void* context);
 typedef int(*light_fn_close)(void* context);
 

--- a/src/light_io_mem.c
+++ b/src/light_io_mem.c
@@ -59,7 +59,7 @@ size_t light_mem_write(void* context, const void* buf, size_t count)
 	return len;
 }
 
-int64_t light_mem_seek(void* context, int64_t offset, int origin)
+int light_mem_seek(void* context, off_t offset, int origin)
 {
 	mem_context* mem = context;
 	size_t new_offset = -1;
@@ -82,7 +82,7 @@ int64_t light_mem_seek(void* context, int64_t offset, int origin)
 	return 0;
 }
 
-int64_t light_mem_offset(void* context)
+off_t light_mem_offset(void* context)
 {
 	mem_context* mem = context;
 

--- a/src/light_io_mem.c
+++ b/src/light_io_mem.c
@@ -59,7 +59,7 @@ size_t light_mem_write(void* context, const void* buf, size_t count)
 	return len;
 }
 
-int light_mem_seek(void* context, long int offset, int origin)
+int64_t light_mem_seek(void* context, int64_t offset, int origin)
 {
 	mem_context* mem = context;
 	size_t new_offset = -1;
@@ -80,6 +80,13 @@ int light_mem_seek(void* context, long int offset, int origin)
 	}
 	mem->offset = new_offset;
 	return 0;
+}
+
+int64_t light_mem_offset(void* context)
+{
+	mem_context* mem = context;
+
+	return mem->offset;
 }
 
 int light_mem_flush(void* context)
@@ -107,6 +114,8 @@ light_file light_io_mem_create(void* memory, size_t size)
 	fd->context = mem;
 	fd->fn_read = &light_mem_read;
 	fd->fn_write = &light_mem_write;
+	fd->fn_seek = &light_mem_seek;
+	fd->fn_offset = &light_mem_offset;
 	fd->fn_flush = &light_mem_flush;
 	fd->fn_close = &light_mem_close;
 	return fd;

--- a/src/light_io_zlib.c
+++ b/src/light_io_zlib.c
@@ -30,6 +30,11 @@ int light_zlib_seek(void* context, long int offset, int origin)
 	return gzseek((gzFile)context, offset, origin);
 }
 
+long light_zlib_tell(void* context)
+{
+	return gzoffset64((gzFile)context);
+}
+
 int light_zlib_close(void* context)
 {
 	return gzclose((gzFile)context);
@@ -49,6 +54,7 @@ light_file light_io_zlib_open(const char* filename, const char* mode)
 	fd->fn_write = &light_zlib_write;
 	fd->fn_flush = &light_zlib_flush;
 	fd->fn_seek = &light_zlib_seek;
+	fd->fn_tell = &light_zlib_tell;
 	fd->fn_close = &light_zlib_close;
 
 	return fd;

--- a/src/light_io_zlib.c
+++ b/src/light_io_zlib.c
@@ -25,14 +25,14 @@ int light_zlib_flush(void* context)
 	return gzflush((gzFile)context, Z_NO_FLUSH);
 }
 
-int64_t light_zlib_seek(void* context, int64_t offset, int origin)
+int light_zlib_seek(void* context, off_t offset, int origin)
 {
-	return gzseek64((gzFile)context, offset, origin);
+	return gzseek((gzFile)context, offset, origin);
 }
 
-int64_t light_zlib_offset(void* context)
+off_t light_zlib_offset(void* context)
 {
-	return gzoffset64((gzFile)context);
+	return gzoffset((gzFile)context);
 }
 
 int light_zlib_close(void* context)

--- a/src/light_io_zlib.c
+++ b/src/light_io_zlib.c
@@ -25,12 +25,12 @@ int light_zlib_flush(void* context)
 	return gzflush((gzFile)context, Z_NO_FLUSH);
 }
 
-int light_zlib_seek(void* context, long int offset, int origin)
+int64_t light_zlib_seek(void* context, int64_t offset, int origin)
 {
-	return gzseek((gzFile)context, offset, origin);
+	return gzseek64((gzFile)context, offset, origin);
 }
 
-long light_zlib_tell(void* context)
+int64_t light_zlib_offset(void* context)
 {
 	return gzoffset64((gzFile)context);
 }
@@ -54,7 +54,7 @@ light_file light_io_zlib_open(const char* filename, const char* mode)
 	fd->fn_write = &light_zlib_write;
 	fd->fn_flush = &light_zlib_flush;
 	fd->fn_seek = &light_zlib_seek;
-	fd->fn_tell = &light_zlib_tell;
+	fd->fn_offset = &light_zlib_offset;
 	fd->fn_close = &light_zlib_close;
 
 	return fd;

--- a/src/light_io_zstd.c
+++ b/src/light_io_zstd.c
@@ -214,6 +214,13 @@ size_t light_zstd_write(void* context, const void* buf, size_t count)
 	return count;
 }
 
+int light_zstd_flush_w(void* context)
+{
+	struct zstd_compression_t* compression = context;
+
+	return fflush(compression->file);
+}
+
 int light_zstd_close_w(void* context)
 {
 	struct zstd_compression_t* compression = context;
@@ -311,6 +318,7 @@ light_file light_io_zstd_open(const char* filename, const char* mode)
 	else {
 		fd->context = get_zstd_compression_context(file, compression_level);
 		fd->fn_write = &light_zstd_write;
+		fd->fn_flush = &light_zstd_flush_w;
 		fd->fn_close = &light_zstd_close_w;
 	}
 	

--- a/src/light_io_zstd.c
+++ b/src/light_io_zstd.c
@@ -214,6 +214,13 @@ size_t light_zstd_write(void* context, const void* buf, size_t count)
 	return count;
 }
 
+long light_zstd_tell_w(void* context)
+{
+	struct zstd_compression_t* compression = context;
+
+	return ftell(compression->file);
+}
+
 int light_zstd_flush_w(void* context)
 {
 	struct zstd_compression_t* compression = context;
@@ -245,6 +252,13 @@ int light_zstd_close_w(void* context)
 	free(compression);
 
 	return res;
+}
+
+long light_zstd_tell_r(void* context)
+{
+	struct zstd_decompression_t* decompression = context;
+
+	return ftell(decompression->file);
 }
 
 int light_zstd_close_r(void* context)
@@ -313,11 +327,13 @@ light_file light_io_zstd_open(const char* filename, const char* mode)
 	if (read) {
 		fd->context = get_zstd_decompression_context(file);
 		fd->fn_read = &light_zstd_read;
+		fd->fn_tell = &light_zstd_tell_r;
 		fd->fn_close = &light_zstd_close_r;
 	}
 	else {
 		fd->context = get_zstd_compression_context(file, compression_level);
 		fd->fn_write = &light_zstd_write;
+		fd->fn_tell = &light_zstd_tell_w;
 		fd->fn_flush = &light_zstd_flush_w;
 		fd->fn_close = &light_zstd_close_w;
 	}

--- a/src/light_io_zstd.c
+++ b/src/light_io_zstd.c
@@ -214,11 +214,11 @@ size_t light_zstd_write(void* context, const void* buf, size_t count)
 	return count;
 }
 
-long light_zstd_tell_w(void* context)
+int64_t light_zstd_offset_w(void* context)
 {
 	struct zstd_compression_t* compression = context;
 
-	return ftell(compression->file);
+	return ftello64(compression->file);
 }
 
 int light_zstd_flush_w(void* context)
@@ -254,11 +254,11 @@ int light_zstd_close_w(void* context)
 	return res;
 }
 
-long light_zstd_tell_r(void* context)
+int64_t light_zstd_offset_r(void* context)
 {
 	struct zstd_decompression_t* decompression = context;
 
-	return ftell(decompression->file);
+	return ftello64(decompression->file);
 }
 
 int light_zstd_close_r(void* context)
@@ -327,13 +327,13 @@ light_file light_io_zstd_open(const char* filename, const char* mode)
 	if (read) {
 		fd->context = get_zstd_decompression_context(file);
 		fd->fn_read = &light_zstd_read;
-		fd->fn_tell = &light_zstd_tell_r;
+		fd->fn_offset = &light_zstd_offset_r;
 		fd->fn_close = &light_zstd_close_r;
 	}
 	else {
 		fd->context = get_zstd_compression_context(file, compression_level);
 		fd->fn_write = &light_zstd_write;
-		fd->fn_tell = &light_zstd_tell_w;
+		fd->fn_offset = &light_zstd_offset_w;
 		fd->fn_flush = &light_zstd_flush_w;
 		fd->fn_close = &light_zstd_close_w;
 	}

--- a/src/light_io_zstd.c
+++ b/src/light_io_zstd.c
@@ -214,11 +214,11 @@ size_t light_zstd_write(void* context, const void* buf, size_t count)
 	return count;
 }
 
-int64_t light_zstd_offset_w(void* context)
+off_t light_zstd_offset_w(void* context)
 {
 	struct zstd_compression_t* compression = context;
 
-	return ftello64(compression->file);
+	return ftello(compression->file);
 }
 
 int light_zstd_flush_w(void* context)
@@ -254,11 +254,11 @@ int light_zstd_close_w(void* context)
 	return res;
 }
 
-int64_t light_zstd_offset_r(void* context)
+off_t light_zstd_offset_r(void* context)
 {
 	struct zstd_decompression_t* decompression = context;
 
-	return ftello64(decompression->file);
+	return ftello(decompression->file);
 }
 
 int light_zstd_close_r(void* context)

--- a/src/light_pcapng_ext.c
+++ b/src/light_pcapng_ext.c
@@ -596,3 +596,8 @@ int light_pcapng_flush(light_pcapng pcapng)
 {
 	return light_io_flush(pcapng->file);
 }
+
+long light_pcapng_tell(light_pcapng pcapng)
+{
+	return light_io_tell(pcapng->file);
+}

--- a/src/light_pcapng_ext.c
+++ b/src/light_pcapng_ext.c
@@ -597,7 +597,7 @@ int light_pcapng_flush(light_pcapng pcapng)
 	return light_io_flush(pcapng->file);
 }
 
-long light_pcapng_tell(light_pcapng pcapng)
+int64_t light_pcapng_offset(light_pcapng pcapng)
 {
-	return light_io_tell(pcapng->file);
+	return light_io_offset(pcapng->file);
 }

--- a/src/light_pcapng_ext.c
+++ b/src/light_pcapng_ext.c
@@ -597,7 +597,7 @@ int light_pcapng_flush(light_pcapng pcapng)
 	return light_io_flush(pcapng->file);
 }
 
-int64_t light_pcapng_offset(light_pcapng pcapng)
+off_t light_pcapng_offset(light_pcapng pcapng)
 {
 	return light_io_offset(pcapng->file);
 }


### PR DESCRIPTION
* seek function for light_io_file.
* flush function for light_io_zstd writes.
* Add new tell functions — for light_io_file, light_io_zlib and light_io_zstd.
* Add a new API call `light_pcapng_tell()` to call the light_io tell functions.

The tell functions would be useful to find the size of the pcapng file when writing. This would allow eg output that stops when a maximum size is reached, or log file rotation.