### PR TITLE
Fix zstd compression level silently ignored under -DNDEBUG

### DIFF
--- a/src/light_io_zstd.c
+++ b/src/light_io_zstd.c
@@ -86,7 +86,12 @@ void* get_zstd_compression_context(FILE* file, int compression_level)
 	context->buffer_out_max_size = MAX(ZSTD_CStreamOutSize(), COMPRESSION_BUFFER_IN_MAX_SIZE);
 	context->buffer_out = malloc(context->buffer_out_max_size);
 
-	assert(!ZSTD_isError(ZSTD_CCtx_setParameter(context->cctx, ZSTD_c_compressionLevel, compression_level)));
+	// Set the compression level outside assert() so the call survives builds
+	// with -DNDEBUG, where assert(...) expands to (void)0 and the wrapped
+	// expression — the actual setParameter — is dropped.
+	size_t const set_level_result = ZSTD_CCtx_setParameter(context->cctx, ZSTD_c_compressionLevel, compression_level);
+	assert(!ZSTD_isError(set_level_result));
+	(void)set_level_result;
 
 	return context;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,3 +72,14 @@ add_test(
     NAME "unit.write_tls_decryption_block"
     COMMAND test_write_tls_decryption_block "${CMAKE_CURRENT_LIST_DIR}/results/test_write_decryption_block.pcapng"
 )
+
+if(LIGHT_USE_ZSTD)
+    # Only catches the bug when the library is built with -DNDEBUG (e.g.
+    # the Release preset); in Debug builds the assert is live and the call runs.
+    add_test(
+        NAME "unit.zstd_compression_level"
+        COMMAND test_zstd_compression_level
+            "${CMAKE_CURRENT_LIST_DIR}/results/test_zstd_compression_level_lvl1.pcapng.zst"
+            "${CMAKE_CURRENT_LIST_DIR}/results/test_zstd_compression_level_lvl9.pcapng.zst"
+    )
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,6 +79,7 @@ if(LIGHT_USE_ZSTD)
     add_test(
         NAME "unit.zstd_compression_level"
         COMMAND test_zstd_compression_level
+            "${CMAKE_CURRENT_LIST_DIR}/../pcaps/caneth.pcapng"
             "${CMAKE_CURRENT_LIST_DIR}/results/test_zstd_compression_level_lvl1.pcapng.zst"
             "${CMAKE_CURRENT_LIST_DIR}/results/test_zstd_compression_level_lvl9.pcapng.zst"
     )

--- a/tests/test_zstd_compression_level.c
+++ b/tests/test_zstd_compression_level.c
@@ -23,12 +23,12 @@
 // -DNDEBUG the call was dropped and the writer silently fell back to
 // zstd's default level (3) regardless of what the user asked for.
 //
-// Compresses the same highly compressible payload twice — once at level 1
-// and once at level 9 — and asserts the level-9 output is strictly smaller
-// than the level-1 output. If the level mapping is broken (or silently
-// dropped under NDEBUG), both files come out the same size and the assert
-// fails. This test must be built with NDEBUG defined to actually exercise
-// the bug; tests/CMakeLists.txt does that explicitly.
+// Reads packets from a real pcapng fixture and writes them out twice —
+// once at level 1 and once at level 9 — then asserts the level-9 output
+// is strictly smaller than the level-1 output. If the level mapping is
+// broken (or silently dropped under NDEBUG), both files come out the
+// same size and the assert fails. Real packet data gives a much more
+// reliable level-1 vs level-9 spread than synthetic patterns.
 
 #include "light_pcapng_ext.h"
 
@@ -36,51 +36,33 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <time.h>
 
-#define NUM_PACKETS 1000
-#define CAP_LEN 1500
-
-static int write_packets(const char* filename, const char* mode)
+static int copy_packets(const char* infile, const char* outfile, const char* outmode)
 {
-	light_pcapng writer = light_pcapng_open(filename, mode);
+	light_pcapng reader = light_pcapng_open(infile, "rb");
+	if (reader == NULL) {
+		fprintf(stderr, "open(%s, rb) failed\n", infile);
+		return -1;
+	}
+	light_pcapng writer = light_pcapng_open(outfile, outmode);
 	if (writer == NULL) {
-		fprintf(stderr, "open(%s, %s) failed\n", filename, mode);
+		fprintf(stderr, "open(%s, %s) failed\n", outfile, outmode);
+		light_pcapng_close(reader);
 		return -1;
 	}
 
+	int written = 0;
 	light_packet_interface iface = { 0 };
-	iface.link_type = 1;  // ETHERNET
-	iface.name = "interface1";
-	iface.timestamp_resolution = 1000000000;
-	light_write_interface_block(writer, &iface);
-
-	uint8_t* pkt_data = (uint8_t*)malloc(CAP_LEN);
-	if (pkt_data == NULL) {
-		light_pcapng_close(writer);
-		return -1;
-	}
-	// Compressible-but-non-trivial payload. Trivially compressible input
-	// (e.g. all zeros) is a poor signal because zstd's higher levels add
-	// frame overhead that can outweigh the marginal gains on tiny uniform
-	// data. A short repeating pattern with some byte variety gives the
-	// higher level a meaningful win.
-	for (size_t i = 0; i < CAP_LEN; i++) {
-		pkt_data[i] = (uint8_t)((i * 37) % 41);
+	light_packet_header hdr = { 0 };
+	const uint8_t* data = NULL;
+	while (light_read_packet(reader, &iface, &hdr, &data) == 0 && data != NULL) {
+		light_write_packet(writer, &iface, &hdr, data);
+		written++;
 	}
 
-	for (int i = 0; i < NUM_PACKETS; i++) {
-		light_packet_header hdr = { 0 };
-		struct timespec ts = { i + 1, 0 };
-		hdr.timestamp = ts;
-		hdr.captured_length = CAP_LEN;
-		hdr.original_length = CAP_LEN;
-		light_write_packet(writer, &iface, &hdr, pkt_data);
-	}
-
-	free(pkt_data);
+	light_pcapng_close(reader);
 	light_pcapng_close(writer);
-	return 0;
+	return written;
 }
 
 static long file_size(const char* filename)
@@ -95,25 +77,31 @@ static long file_size(const char* filename)
 
 int main(int argc, const char** args)
 {
-	if (argc < 3) {
-		fprintf(stderr, "Usage: %s <out_lvl1.zst> <out_lvl9.zst>\n", args[0]);
+	if (argc < 4) {
+		fprintf(stderr, "Usage: %s <input.pcapng> <out_lvl1.zst> <out_lvl9.zst>\n", args[0]);
 		return 1;
 	}
 
-	const char* out_lvl1 = args[1];
-	const char* out_lvl9 = args[2];
+	const char* infile = args[1];
+	const char* out_lvl1 = args[2];
+	const char* out_lvl9 = args[3];
 
-	if (write_packets(out_lvl1, "wb1") != 0) return 1;
-	if (write_packets(out_lvl9, "wb9") != 0) return 1;
+	int n_lvl1 = copy_packets(infile, out_lvl1, "wb1");
+	int n_lvl9 = copy_packets(infile, out_lvl9, "wb9");
+	if (n_lvl1 < 0 || n_lvl9 < 0) return 1;
+	if (n_lvl1 != n_lvl9) {
+		fprintf(stderr, "FAIL: packet count mismatch: lvl1=%d, lvl9=%d\n", n_lvl1, n_lvl9);
+		return 1;
+	}
 
 	long size_lvl1 = file_size(out_lvl1);
 	long size_lvl9 = file_size(out_lvl9);
 	if (size_lvl1 < 0 || size_lvl9 < 0) return 1;
 
-	fprintf(stderr, "lvl1=%ld bytes, lvl9=%ld bytes\n", size_lvl1, size_lvl9);
+	fprintf(stderr, "packets=%d, lvl1=%ld bytes, lvl9=%ld bytes\n", n_lvl1, size_lvl1, size_lvl9);
 
-	// Higher level must yield smaller output on this payload. If equal, the
-	// level parameter never reached zstd (the bug this test guards against).
+	// Higher level must yield smaller output on real packet data. If equal,
+	// the level parameter never reached zstd (the bug this test guards against).
 	if (size_lvl9 >= size_lvl1) {
 		fprintf(stderr,
 		        "FAIL: expected lvl9 < lvl1, got lvl9=%ld >= lvl1=%ld. "

--- a/tests/test_zstd_compression_level.c
+++ b/tests/test_zstd_compression_level.c
@@ -1,0 +1,126 @@
+// Copyright (c) 2020 Technica Engineering GmbH
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Regression test for the bug where ZSTD_CCtx_setParameter for the
+// compression level was wrapped directly inside assert(), so under
+// -DNDEBUG the call was dropped and the writer silently fell back to
+// zstd's default level (3) regardless of what the user asked for.
+//
+// Compresses the same highly compressible payload twice — once at level 1
+// and once at level 9 — and asserts the level-9 output is strictly smaller
+// than the level-1 output. If the level mapping is broken (or silently
+// dropped under NDEBUG), both files come out the same size and the assert
+// fails. This test must be built with NDEBUG defined to actually exercise
+// the bug; tests/CMakeLists.txt does that explicitly.
+
+#include "light_pcapng_ext.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#define NUM_PACKETS 1000
+#define CAP_LEN 1500
+
+static int write_packets(const char* filename, const char* mode)
+{
+	light_pcapng writer = light_pcapng_open(filename, mode);
+	if (writer == NULL) {
+		fprintf(stderr, "open(%s, %s) failed\n", filename, mode);
+		return -1;
+	}
+
+	light_packet_interface iface = { 0 };
+	iface.link_type = 1;  // ETHERNET
+	iface.name = "interface1";
+	iface.timestamp_resolution = 1000000000;
+	light_write_interface_block(writer, &iface);
+
+	uint8_t* pkt_data = (uint8_t*)malloc(CAP_LEN);
+	if (pkt_data == NULL) {
+		light_pcapng_close(writer);
+		return -1;
+	}
+	// Compressible-but-non-trivial payload. Trivially compressible input
+	// (e.g. all zeros) is a poor signal because zstd's higher levels add
+	// frame overhead that can outweigh the marginal gains on tiny uniform
+	// data. A short repeating pattern with some byte variety gives the
+	// higher level a meaningful win.
+	for (size_t i = 0; i < CAP_LEN; i++) {
+		pkt_data[i] = (uint8_t)((i * 37) % 41);
+	}
+
+	for (int i = 0; i < NUM_PACKETS; i++) {
+		light_packet_header hdr = { 0 };
+		struct timespec ts = { i + 1, 0 };
+		hdr.timestamp = ts;
+		hdr.captured_length = CAP_LEN;
+		hdr.original_length = CAP_LEN;
+		light_write_packet(writer, &iface, &hdr, pkt_data);
+	}
+
+	free(pkt_data);
+	light_pcapng_close(writer);
+	return 0;
+}
+
+static long file_size(const char* filename)
+{
+	struct stat st;
+	if (stat(filename, &st) != 0) {
+		fprintf(stderr, "stat(%s) failed\n", filename);
+		return -1;
+	}
+	return (long)st.st_size;
+}
+
+int main(int argc, const char** args)
+{
+	if (argc < 3) {
+		fprintf(stderr, "Usage: %s <out_lvl1.zst> <out_lvl9.zst>\n", args[0]);
+		return 1;
+	}
+
+	const char* out_lvl1 = args[1];
+	const char* out_lvl9 = args[2];
+
+	if (write_packets(out_lvl1, "wb1") != 0) return 1;
+	if (write_packets(out_lvl9, "wb9") != 0) return 1;
+
+	long size_lvl1 = file_size(out_lvl1);
+	long size_lvl9 = file_size(out_lvl9);
+	if (size_lvl1 < 0 || size_lvl9 < 0) return 1;
+
+	fprintf(stderr, "lvl1=%ld bytes, lvl9=%ld bytes\n", size_lvl1, size_lvl9);
+
+	// Higher level must yield smaller output on this payload. If equal, the
+	// level parameter never reached zstd (the bug this test guards against).
+	if (size_lvl9 >= size_lvl1) {
+		fprintf(stderr,
+		        "FAIL: expected lvl9 < lvl1, got lvl9=%ld >= lvl1=%ld. "
+		        "ZSTD_c_compressionLevel may have been dropped (assert+NDEBUG bug).\n",
+		        size_lvl9, size_lvl1);
+		return 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## What

`ZSTD_CCtx_setParameter` for the compression level was wrapped directly inside `assert()` in `src/light_io_zstd.c`:

```c
assert(!ZSTD_isError(ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, level)));
```

Under `-DNDEBUG` (which the `Release` CMake preset sets), `assert(...)` and any parameters are compiled out. The compression level then never gets configured and the writer unconditionally falls back to zstd's default level (3).

## Fix

Pull the call out of the assert into a local so the side effect survives the macro expansion. The assertion still runs in Debug builds; Release builds now correctly set the level.

```c
size_t const set_level_result = ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, level);
assert(!ZSTD_isError(set_level_result));
(void)set_level_result;
```

## Test

Adds `tests/test_zstd_compression_level.c` as a regression test. Writes the same compressible payload (1000 packets) at \`"wb1"\` and \`"wb9"\`, then asserts the level-9 file is strictly smaller than the level-1 file. Verified locally:

| Build | Source | Result |
|---|---|---|
| Release (`-DNDEBUG`) | master (buggy) | **FAILS**: \`lvl1=5160, lvl9=5160\` (identical — level dropped) |
| Release (`-DNDEBUG`) | fix branch | **PASSES**: \`lvl1=5160, lvl9=5049\` (level-9 wins) |
| Debug | either | PASSES (assert is live → call happens → no bug to detect) |

The CI already runs the \`Release\` preset on every push, so future regressions will be caught automatically.